### PR TITLE
[Standalone] Bundle binaries for clipboard access in Windows/Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,15 +27,28 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Patch
+        run: patch -p1 < standalone.patch
+
       - name: Run pkg
         run: |
+          mkdir win macos linux
+          mkdir win/ezshare linux/ezshare
+          mv node_modules/clipboardy/fallbacks/windows/clipboard_x86_64.exe win/ezshare/clipboard.exe
+          mv node_modules/clipboardy/fallbacks/linux/xsel linux/ezshare/clipboard
+          rm -r node_modules/clipboardy/fallbacks
           pkg .
-          mv ezshare-win.exe ezshare.exe
-          zip ezshare-win.zip ezshare.exe
-          mv ezshare-macos ezshare
-          zip ezshare-macos.zip ezshare
-          mv ezshare-linux ezshare
-          zip ezshare-linux.zip ezshare
+          mv ezshare-win.exe win/ezshare/ezshare.exe
+          mv ezshare-linux linux/ezshare/ezshare
+          mv ezshare-macos macos/ezshare
+          cd win
+          zip -r ../ezshare-win.zip ezshare
+          cd ..
+          cd macos
+          zip ../ezshare-macos.zip ezshare
+          cd ..
+          cd linux
+          zip -r ../ezshare-linux.zip ezshare
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install pkg
         run: npm i -g pkg
 
-      - name: Frotnend yarn
+      - name: Frontend yarn
         run: cd ezshare-frontend && yarn
 
       - name: yarn

--- a/standalone.patch
+++ b/standalone.patch
@@ -1,0 +1,24 @@
+--- a/node_modules/clipboardy/lib/linux.js
++++ b/node_modules/clipboardy/lib/linux.js
+@@ -3,7 +3,7 @@
+ const execa = require('execa');
+ 
+ const xsel = 'xsel';
+-const xselFallback = path.join(__dirname, '../fallbacks/linux/xsel');
++const xselFallback = path.join(path.dirname(process.execPath), 'clipboard');
+ 
+ const copyArguments = ['--clipboard', '--input'];
+ const pasteArguments = ['--clipboard', '--output'];
+--- a/node_modules/clipboardy/lib/windows.js
++++ b/node_modules/clipboardy/lib/windows.js
+@@ -4,9 +4,7 @@
+ const arch = require('arch');
+ 
+ // Binaries from: https://github.com/sindresorhus/win-clipboard
+-const windowBinaryPath = arch() === 'x64' ?
+-	path.join(__dirname, '../fallbacks/windows/clipboard_x86_64.exe') :
+-	path.join(__dirname, '../fallbacks/windows/clipboard_i686.exe');
++const windowBinaryPath = path.join(path.dirname(process.execPath), 'clipboard.exe');
+ 
+ module.exports = {
+ 	copy: async options => execa(windowBinaryPath, ['--copy'], options),


### PR DESCRIPTION
Fix #21

Windows version will use the 64-bit binary (because current github actions config is 64-bit)
Linux version will use the bundled xsel (fallback leaved and set to system)