### PR TITLE
Make uploads post to the currently browsed directory

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,11 +44,13 @@ module.exports = ({ sharedPath: sharedPathIn, port, maxUploadSize, zipCompressio
   app.post('/api/upload', asyncHandler(async (req, res) => {
     // console.log(req.headers)
 
+    let currentDir = getFilePath(req.query.f);
+
     // parse a file upload
     const form = new formidable({
       multiples: true,
       keepExtensions: true,
-      uploadDir: sharedPath,
+      uploadDir: currentDir,
       maxFileSize: maxUploadSize,
       maxFields,
     });
@@ -64,12 +66,12 @@ module.exports = ({ sharedPath: sharedPathIn, port, maxUploadSize, zipCompressio
         const files = Array.isArray(filesIn) ? filesIn : [filesIn];
 
         // console.log(JSON.stringify({ fields, files }, null, 2));
-        console.log('Uploaded files:');
+        console.log(`Uploaded files (${currentDir}):`);
         files.forEach((f) => console.log(f.name, `(${f.size} bytes)`));
 
         await pMap(files, async (file) => {
           try {
-            const targetPath = join(sharedPath, filenamify(file.name));
+            const targetPath = join(currentDir, filenamify(file.name));
             if (!(await fs.pathExists(targetPath))) await fs.rename(file.path, targetPath);
           } catch (err) {
             console.error(`Failed to rename ${file.name}`, err);

--- a/ezshare-frontend/src/App.js
+++ b/ezshare-frontend/src/App.js
@@ -47,7 +47,7 @@ const Section = ({ children, style }) => (
   </div>
 );
 
-const Uploader = ({ onUploadSuccess }) => {
+const Uploader = ({ onUploadSuccess, targetPath }) => {
   const [uploadProgress, setUploadProgress] = useState();
   const [uploadSpeed, setUploadSpeed] = useState();
 
@@ -77,7 +77,7 @@ const Uploader = ({ onUploadSuccess }) => {
           if (dataLoaded && startTime) setUploadSpeed(dataLoaded / ((new Date().getTime() - startTime) / 1000));
         }
 
-        await axios.post('/api/upload', data, { onUploadProgress });
+        await axios.post(`/api/upload?f=${encodeURIComponent(targetPath)}`, data, { onUploadProgress });
 
         Toast.fire({ icon: 'success', title: 'File(s) uploaded successfully' });
         onUploadSuccess();
@@ -92,7 +92,7 @@ const Uploader = ({ onUploadSuccess }) => {
     }
 
     upload();
-  }, [onUploadSuccess]);
+  }, [onUploadSuccess, targetPath]);
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop });
 
@@ -263,12 +263,7 @@ const Browser = () => {
       </Section>
 
       <Section>
-        <h2>Upload files</h2>
-        <Uploader onUploadSuccess={handleUploadSuccess} />
-      </Section>
-
-      <Section>
-        <h2>Download files</h2>
+        <h2>Files</h2>
 
         <div style={{ wordBreak: 'break-all', padding: '0 5px 8px 5px', fontSize: '.85em', color: 'rgba(0,0,0,0.3)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <FaShareAlt size={10} style={{ marginRight: 10 }} />
@@ -284,6 +279,10 @@ const Browser = () => {
 
         {dirs.map(FileRow)}
         {nonDirs.map(FileRow)}
+      </Section>
+
+      <Section>
+        <Uploader onUploadSuccess={handleUploadSuccess} targetPath={currentPath}/>
       </Section>
 
       {/* eslint-disable-next-line jsx-a11y/accessible-emoji */}


### PR DESCRIPTION
Hello! Love this project.; really thankful that it exists, as it was EXACTLY what I was looking for.

When I first deployed it, I was surprised that uploading only places the file in the root directory and not the browsed directory. I made a small change to have uploads go to the currently browsed directory instead. 

To make the using of the browsing directory common to both uploads and downloads more obvious, the Download Files and Upload Files sections on the frontend were merged as well. Don't know if that's "too bold" of a change, but I thought I'd add it and leave it up to you whether this change is for the better.